### PR TITLE
feat: allow specifying the executable to use (e.g 'terragrunt')

### DIFF
--- a/README.md
+++ b/README.md
@@ -10,6 +10,9 @@ With its latest version you can easily visualize the complete state tree, gainin
 
 ## Key Features
 
+### version 0.5
+- [x] Added support for terragrunt (and other Terraform wrappers); courtesy of [@jonwtech](https://github.com/jonwtech)
+
 ### version 0.4
 - [x] Fixed the erroneous flattening of submodules
 - [x] Added collapse levels for the state tree


### PR DESCRIPTION
Adds an `'-e', '--executable'` argument that allows overriding the default executable (`terraform`.)

This enables Terragrunt usage (**https://github.com/idoavrah/terraform-tui/issues/15**), for example:

```$ tftui -e terragrunt```