### PR TITLE
Fix parsing of new blocks in state

### DIFF
--- a/tftui/state.py
+++ b/tftui/state.py
@@ -107,7 +107,7 @@ class State:
 
         contents = ""
         for line in state_output:
-            if line.startswith("#"):
+            if line.startswith("# "):
                 (fullname, name, submodule, type, is_tainted) = State.parse_block(line)
                 contents = ""
             elif line.startswith("}"):


### PR DESCRIPTION
This change fixes the parsing of a Terraform state by only creating new blocks if the line starts with `# ` - note the space after the hash.

This is required because the state can contain arbitrary data, e.g. the raw content of a file (from `data.local_file`, which can start with a `#` - this is what happened in my case.

I hope that hash + whitespace will only occur if a new block starts.

---

### Background

When I ran the TUI on one of my Terraform modules, I only got the following message in the output before it exited:

```
substring not found
```

After closing the repo and running the app in a debugger, I could get the actual exception:

```
  File "/home/rafael/repos/rafaelwo/terraform-tui/tftui/state.py", line 78, in parse_block
    fullname = line[2 : line.rindex(":")]
                        ^^^^^^^^^^^^^^^^
  File "/home/rafael/repos/rafaelwo/terraform-tui/tftui/state.py", line 104, in refresh_state
    (fullname, name, submodule, type, is_tainted) = State.parse_block(line)
  File "/home/rafael/repos/rafaelwo/terraform-tui/tftui/state.py", line 138, in <module>
    asyncio.run(state.refresh_state())
ValueError: substring not found
```

(Maybe the full exception could be printed - at least in the debug logs?)

This happened due to the current `line` in the state file being 
```
#�uǱ�>�D\x121�3k
```
and the app failed to parse it as a new block - obviously.

With the proposed fix, the TUI app works perfectly on my module of interest :slightly_smiling_face: 