### PR TITLE
fix: guard _on_resize against switcher not yet composed (#92)

### DIFF
--- a/tftui/__main__.py
+++ b/tftui/__main__.py
@@ -669,7 +669,8 @@ class TerraformTUI(App):
 
     def _on_resize(self, event):
         main_height = max(event.size.height - 11, 5)
-        self.switcher.styles.height = main_height
+        if self.switcher is not None:
+            self.switcher.styles.height = main_height
         logger.debug("Main height: %s", main_height)
         super()._on_resize(event)
 


### PR DESCRIPTION
Closes #92.

The class-level `switcher = None` default is rebound to the actual widget in `on_mount` (`self.switcher = self.get_widget_by_id("switcher")`), but `_on_resize` can fire before that runs (the issue's stack trace is from the initial Resize event on first start). Nil-check before reading `.styles` so the resize handler is a no-op until the widget is composed.